### PR TITLE
Add seperate documentation button README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 _Command line interface for managing [Frame hybrid models](https://frame-dev.epfl.ch/)_
 
 [![PyPI version](https://badge.fury.io/py/frame-cli.svg)](https://badge.fury.io/py/frame-cli)
-[![Docs](https://github.com/CHANGE-EPFL/frame-project-cli/actions/workflows/docs.yaml/badge.svg)](https://change-epfl.github.io/frame-project-cli/)
+[![Docs](https://github.com/CHANGE-EPFL/frame-project-cli/actions/workflows/docs.yaml/badge.svg)](https://github.com/CHANGE-EPFL/frame-project-cli/actions/workflows/docs.yaml)
+[![Docs](https://img.shields.io/badge/documentation-main-blue.svg)](https://change-epfl.github.io/frame-project-cli/)
 
 
 # 🐇 Quick start


### PR DESCRIPTION
Suggestion for minor change in README:
- Docs passing button referring to the workflow
- Documentation main button referring to the actual docs  
