### PR TITLE
feat: add more references to github repo in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Frame CLI Documentation
 
-Welcome to the Frame CLI documentation!
+Welcome to the [Frame CLI](https://github.com/CHANGE-EPFL/frame-project-cli) documentation!
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/src/developer/developer_guide.md
+++ b/docs/src/developer/developer_guide.md
@@ -10,7 +10,7 @@ reference
 
 ## 💾 Installation for development
 
-To install Frame CLI for development in your current Python environment, you can use the following command. Feel free to use a virtual environment if you want to keep your system clean.
+The FRAME CLI source code is hosted on [GitHub](https://github.com/CHANGE-EPFL/frame-project-cli). To install Frame CLI for development in your current Python environment, you can use the following command. Feel free to use a virtual environment if you want to keep your system clean.
 ```bash
 git clone https://github.com/CHANGE-EPFL/frame-project-cli.git
 cd frame-cli


### PR DESCRIPTION
# Describe your changes

In the current documentation, I found it quite hard to find a link back to the github repo. I only found 1 link thusfar
https://github.com/CHANGE-EPFL/frame-project-cli/blob/e0c2e16b8357a3adfebf409f089ec9a489a40956/docs/src/user/quick_start.md?plain=1#L3

Therefore, I suggest adding the link in a few more places for clarity. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] Don't forget to link PR to issue if you are solving one.
