### PR TITLE
feat: add more readable validation error messages

### DIFF
--- a/frame_cli/main.py
+++ b/frame_cli/main.py
@@ -86,7 +86,7 @@ def init() -> None:
 def validate() -> None:
     """Validate new/updated FRAME metadata file for the current project."""
     if metadata.validate():
-        print("Metadata file is valid.")
+        print("Metadata file is valid!")
     else:
         print("Metadata file is not valid.")
 

--- a/frame_cli/metadata.py
+++ b/frame_cli/metadata.py
@@ -110,7 +110,8 @@ def get_model_url() -> str | None:
 
 
 def validate() -> bool:
-    # TODO: use frame-project schemas to validate yaml
+    from pydantic import ValidationError
+
     try:
         metadata = get_metadata()
 
@@ -134,8 +135,10 @@ def validate() -> bool:
 
     try:
         MetadataFromFile(**metadata)
-    except Exception as e:
-        logger.info(f"Invalid metadata file: {e}")
+    except ValidationError as e:
+        logger.info("Validation error in metadata file:")
+        for error in e.errors():
+            logger.info(f"- {error['loc']}: {error['msg']}")
         return False
 
     return True


### PR DESCRIPTION
# Describe your changes

Replace default Pydantic ValidationError display and traceback with formatted list of errors.
Example:

```
❯ frame validate
[14:54:32] INFO     Validation error in metadata file:                      metadata.py:139
           INFO     - ('hybrid_model', 'contributors'): Field required      metadata.py:141
Metadata file is not valid.
```

# Related GitHub issues and pull requests


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Don't forget to link PR to issue if you are solving one.
