### PR TITLE
fix: pydantic version dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,12 @@ authors = [
 ]
 license = {text = "GPL-3.0-or-later"}
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
 	"gitpython~=3.1.43",
 	"pip>=25.1.1",
-	"pydantic~=2.11.4",
+	"pydantic>=2.11.4,<3.0.0",
 	"pygithub>=2.6.1",
 	"python-dotenv~=1.0.1",
 	"pyyaml>=6.0.2",


### PR DESCRIPTION
# Describe your changes

Increase the allowed pydantic dependency version to `<3.0.0` to prevent compilation error when installing frame on Python 3.14.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Don't forget to link PR to issue if you are solving one.
